### PR TITLE
Fix Japan 2012 Experts Final maze file

### DIFF
--- a/classic/japan2012-ef.txt
+++ b/classic/japan2012-ef.txt
@@ -4,7 +4,7 @@ o   o   o   o---o---o---o   o---o---o---o---o   o   o   o   o   o
 |   |   |   |       |       |                   |   |   |   |   |
 o   o   o   o   o   o   o---o   o---o---o---o---o   o   o   o   o
 |   |       |   |           |                   |   |       |   |
-o   o---o---o   o---o---o---o---o---o---o---o   o   o---o---o   o
+o   o---o---o   o   o---o---o---o---o---o---o   o   o---o---o   o
 |               |   |                           |           |   |
 o   o---o---o---o   o   o---o---o---o---o---o   o---o---o   o   o
 |   |               |   |               |       |           |   |
@@ -23,7 +23,7 @@ o   o---o   o---o   o   o   o   o   o---o---o   o---o---o   o   o
 o---o---o---o---o   o   o   o   o   o   o---o   o---o   o   o   o
 |                   |   |   |       |           |       |   |   |
 o   o---o---o---o   o   o   o   o   o   o---o---o   o---o   o   o
-|           |       |           |   |   |       |   |       |   |
+|           |       |           |       |       |   |       |   |
 o---o---o   o---o   o---o---o   o---o   o   o   o   o   o---o   o
 |       |       |           |           |   |   |   |           |
 o   o   o   o   o   o---o   o---o---o---o   o   o   o   o---o---o


### PR DESCRIPTION
I picked a few random mazes to add to my image-to-maze-file conversion tool test suite. One of them was the Japan 2012 Experts Final maze.

I took the reference image from [http://www.ntf.or.jp](http://www.ntf.or.jp/mouse/history/index.html), but when I run it and compared the output to your `japan2012ef.txt` file they differed. I think your version might be incorrect.

I have seen in your [micromouseonline post](http://www.micromouseonline.com/2012/11/29/japan-2012-finals/) that you mention the image they published was incorrect, but you also mention a couple of run times:

- Tushi2 from Southern Taiwan University ran next and ended with a time of 7.202
- Its reliability was excellent and it posted a final best time of 9.764.

These are the videos I have found where you can see those run times displayed (and you can also check the actual maze setup):

- https://youtu.be/laLLOHDIgZg?t=14s
- https://youtu.be/Rp5MUug5rT0?t=1m15s

In those videos you can see that the 2 walls you added are not there.