### PR TITLE
Add RoboChallenge 2024 (Brazil) mazes

### DIFF
--- a/classic/br2024-robochallenge-day1.txt
+++ b/classic/br2024-robochallenge-day1.txt
@@ -1,0 +1,33 @@
+o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o
+|               |   |                                           |
+o   o---o---o---o   o---o---o---o---o---o---o   o---o   o---o   o
+|   |                                       |   |   |   |   |   |
+o   o---o---o---o   o   o   o---o---o---o   o   o   o   o   o   o
+|                   |   |                   |   |   |   |   |   |
+o   o---o---o   o---o   o   o---o---o---o   o   o   o   o   o   o
+|   |               |   |   |               |   |   |   |   |   |
+o   o   o---o---o---o   o   o   o   o---o   o---o   o   o   o   o
+|   |   |               |   |   |   |           |   |   |   |   |
+o   o   o   o---o---o---o---o---o   o---o   o   o   o   o   o   o
+|   |   |   |       |                   |   |   |   |   |   |   |
+o   o   o   o   o   o   o---o---o---o---o   o   o   o   o   o---o
+|   |   |   |   |   |   |               |   |   |               |
+o   o   o   o   o   o   o   o---o---o   o   o   o---o   o---o---o
+|   |   |       |   |   |   | G   G |   |   |       |           |
+o   o   o---o   o   o   o   o   o   o   o   o---o   o   o---o---o
+|   |           |   |   |   | G   G     |   |   |   |   |       |
+o   o---o---o---o   o---o---o---o---o   o   o   o   o   o   o   o
+|   |           |       |               |   |   |   |       |   |
+o   o---o---o   o   o   o   o---o---o   o---o   o   o   o---o   o
+|               |   |   |   |       |       |   |   |   |       |
+o   o---o---o   o   o   o   o   o   o---o   o   o   o   o---o---o
+|   |               |   |   |   |           |               |   |
+o   o---o   o   o   o   o   o   o---o---o---o---o   o   o   o   o
+|   |       |   |   |   |                       |   |   |       |
+o   o   o---o   o---o   o   o---o---o---o   o---o   o   o   o   o
+|   |   |       |       |   |                       |   |   |   |
+o   o   o   o---o   o   o---o   o---o---o   o---o---o   o   o   o
+|   |   |   |       |                                   |   |   |
+o   o---o   o   o   o   o---o   o---o---o---o---o---o---o   o---o
+| S |           |   |       |                                   |
+o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o

--- a/classic/br2024-robochallenge-day2.txt
+++ b/classic/br2024-robochallenge-day2.txt
@@ -1,0 +1,33 @@
+o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o
+|                       |                                       |
+o   o---o   o   o---o---o   o   o   o---o---o---o---o---o---o   o
+|   |       |               |   |                           |   |
+o   o   o---o   o---o   o   o   o   o---o---o---o---o---o   o   o
+|   |       |   |       |   |   |   |                       |   |
+o   o---o   o   o   o   o---o---o---o   o---o---o---o---o---o   o
+|   |       |       |   |                                   |   |
+o   o   o---o---o   o---o   o---o---o---o---o---o---o---o   o   o
+|   |   |       |       |                                   |   |
+o   o   o   o   o---o---o   o---o---o---o---o---o---o---o---o   o
+|   |       |               |                                   |
+o   o   o   o---o   o---o---o   o---o---o   o---o---o---o---o---o
+|       |       |           |   |       |                       |
+o---o   o---o---o---o   o   o---o---o   o   o---o---o   o---o   o
+|                       |   | G   G |   |   |           |   |   |
+o   o---o---o---o---o---o   o   o   o   o   o---o---o---o   o   o
+|   |                   |   | G   G     |               |   |   |
+o   o   o---o---o---o   o---o---o---o   o---o---o---o   o   o   o
+|   |   |               |                               |   |   |
+o   o   o   o---o---o---o   o---o---o---o---o   o---o---o   o   o
+|       |   |                               |               |   |
+o---o   o   o   o---o---o---o---o---o---o   o---o---o---o   o   o
+|       |   |   |                                           |   |
+o   o   o   o   o   o---o---o---o---o---o---o---o---o---o   o   o
+|   |   |   |   |                           |                   |
+o   o   o   o   o---o---o---o---o---o---o   o   o---o---o---o   o
+|   |   |   |                           |   |               |   |
+o   o   o   o   o---o---o---o---o---o   o   o---o---o---o   o   o
+|   |   |       |                       |   |               |   |
+o   o   o---o---o   o   o---o---o---o---o   o   o---o---o---o   o
+| S |               |                                           |
+o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o

--- a/classic/br2024-robochallenge-day3.txt
+++ b/classic/br2024-robochallenge-day3.txt
@@ -1,0 +1,33 @@
+o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o
+|                                                       |       |
+o   o---o---o---o   o---o   o---o---o---o---o   o---o   o   o   o
+|                           |   |               |       |   |   |
+o   o---o---o   o---o---o   o   o   o---o   o   o   o---o---o   o
+|                           |           |   |   |       |       |
+o   o---o   o---o---o---o   o   o---o---o   o   o---o   o   o---o
+|                                       |   |   |               |
+o   o---o---o---o---o---o   o---o---o---o   o   o---o---o---o   o
+|                       |   |           |                       |
+o   o---o---o---o---o   o---o   o---o   o   o   o---o---o   o   o
+|   |                   |           |       |   |           |   |
+o   o   o---o---o---o---o   o---o   o---o---o   o   o---o   o   o
+|   |   |                       |           |   |       |   |   |
+o   o   o   o---o---o---o   o---o---o---o   o   o   o---o   o   o
+|   |   |               |   | G   G |   |   |   |           |   |
+o   o   o---o---o---o   o   o   o   o   o   o   o---o---o   o   o
+|   |                   |   | G   G     |   |   |               |
+o   o---o---o---o---o---o   o---o---o   o   o   o---o   o---o   o
+|                       |               |       |               |
+o   o---o---o---o   o   o---o---o---o---o---o---o   o   o   o   o
+|   |               |   |   |               |       |   |   |   |
+o   o   o---o---o   o   o   o   o   o---o---o   o   o   o   o   o
+|   |           |   |       |   |               |   |   |       |
+o---o---o---o   o   o   o   o   o---o---o---o   o   o   o   o   o
+|               |   |   |   |               |   |   |       |   |
+o   o---o---o   o   o   o   o   o   o---o   o   o   o   o   o   o
+|   |           |           |   |               |       |   |   |
+o   o   o---o---o   o   o---o   o---o---o---o   o   o   o   o   o
+|   |               |   |                   |   |   |   |   |   |
+o   o---o---o---o   o   o   o   o---o---o   o   o   o   o   o   o
+| S |                       |                                   |
+o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o


### PR DESCRIPTION
Add RoboChallenge 2024 (Brazil) mazes. 3 day event with 3 maze configurations.

Maze images for reference:

**Day 1:** ![image](https://github.com/user-attachments/assets/8b225d2f-66a2-460d-a497-8acab2a11dc7)
**Day 2:** ![image](https://github.com/user-attachments/assets/6f27236b-4040-4537-afc6-15826a52022b)
**Day 3:** ![image](https://github.com/user-attachments/assets/acbc9475-cbae-4d00-bc7a-2a41e7bda34d)


