### PR TITLE
Add Japan 2025 classic maze

### DIFF
--- a/classic/alljapan-046-2025-exp-fin.txt
+++ b/classic/alljapan-046-2025-exp-fin.txt
@@ -1,0 +1,33 @@
+o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o
+|   |                                               |           |
+o   o---o   o   o---o---o   o   o   o---o---o   o---o---o   o   o
+|   |       |       |       |   |       |                   |   |
+o   o   o---o---o   o   o---o   o---o   o   o---o---o   o---o   o
+|                   |       |   |       |       |           |   |
+o   o   o---o---o   o---o   o   o   o---o---o   o---o   o   o   o
+|   |       |       |                   |       |       |       |
+o   o---o   o   o   o   o---o---o   o   o   o   o   o---o---o   o
+|   |           |           |       |   |   |           |       |
+o   o   o   o---o---o   o   o---o---o---o   o---o   o   o   o   o
+|       |       |       |   |       |       |       |       |   |
+o   o---o---o   o   o---o   o---o   o   o   o   o---o   o---o   o
+|               |       |   |           |           |       |   |
+o   o   o   o---o---o   o   o   o---o   o---o   o   o   o   o   o
+|   |   |                   | G   G |   |       |       |       |
+o---o   o---o   o---o---o   o   o   o   o   o   o---o   o---o   o
+|   |   |           |   |   | G   G |       |   |       |       |
+o   o   o   o---o---o   o---o---o---o   o---o---o---o---o   o   o
+|               |       |       |       |   |       |       |   |
+o   o---o---o   o   o---o---o   o---o---o   o   o   o   o---o---o
+|       |                           |   |       |               |
+o---o   o   o   o---o---o   o   o---o   o---o   o---o---o   o   o
+|   |       |       |       |       |   |       |   |       |   |
+o   o---o   o---o   o   o---o---o   o   o   o---o   o   o---o   o
+|   |       |               |                   |           |   |
+o   o   o   o   o---o---o   o   o---o---o---o   o---o---o   o   o
+|       |           |               |       |                   |
+o   o   o---o   o   o---o---o   o   o   o---o---o   o   o   o   o
+|   |   |       |       |       |                   |   |   |   |
+o   o   o   o---o---o   o   o---o---o   o---o---o   o---o---o   o
+| S |                                       |                   |
+o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o---o


### PR DESCRIPTION
It looks like the Japan finals for a given season/year are actually held the following year. That being said I tried to follow the naming convention for the other mazes.

Please see https://www.youtube.com/live/YAk1_WndHuw?si=JT6wvWQJqFoQ2Gpa&t=14597 for a screenshot.